### PR TITLE
The canvas, TeamBox and TeamMember use the same "transparent" color, therefore they stack on top of each other

### DIFF
--- a/src/components/Bench.tsx
+++ b/src/components/Bench.tsx
@@ -21,7 +21,7 @@ export const Bench = () => {
       className={classNames(
         "fixed z-30 bottom-0 left-0 flex gap-4 w-3/5 min-h-[96px] max-h-[192px] items-center p-4 flex-wrap overflow-y-auto rounded-3xl",
         {
-          "bg-gradient-to-r from-dam-blue-300 to-transparent":
+          "bg-gradient-to-r from-dam-blue-400/50 to-transparent":
             isTeamMemberBeingDragged,
         }
       )}

--- a/src/components/InfiniteCanvas.tsx
+++ b/src/components/InfiniteCanvas.tsx
@@ -44,7 +44,7 @@ const InfiniteCanvas = () => {
 
   return (
     <div
-      className="relative w-full h-full overflow-hidden border-2 border-dashed bg-dam-blue-100 border-dam-blue-400 overscroll-none"
+      className="relative w-full h-full overflow-hidden border-2 border-dashed bg-dam-blue-400 bg-opacity-[15%] border-dam-blue-400 overscroll-none"
       ref={mergeRefs([canvasRef, teamDropRef])}
       onWheel={handleWheel}
       onPointerMove={handlePointer}

--- a/src/components/team-box/DraggableTeamBox.tsx
+++ b/src/components/team-box/DraggableTeamBox.tsx
@@ -29,7 +29,7 @@ export const DraggableTeamBox = ({ id }: Props) => {
 
   return isInScreen ? (
     <div
-      className="absolute border-2 border-dashed rounded-3xl bg-dam-blue-100 border-dam-blue-400"
+      className="absolute border-2 border-dashed rounded-3xl bg-dam-blue-400 bg-opacity-[15%] border-dam-blue-400"
       style={{
         left: teamBox.x - screen.x,
         top: teamBox.y - screen.y,

--- a/src/components/team-member/TeamMemberBox.tsx
+++ b/src/components/team-member/TeamMemberBox.tsx
@@ -14,7 +14,7 @@ export const TeamMemberBox = ({ id }: Props) => {
 
   return (
     <div
-      className="flex flex-col items-center py-0.5 border-dashed rounded-3xl border-dam-blue-400"
+      className="flex flex-col items-center py-0.5 border-dashed rounded-3xl bg-dam-blue-400 bg-opacity-[15%] border-dam-blue-400"
       style={{
         width: MEMBER_WIDTH,
         height: memberBoxHeight,


### PR DESCRIPTION
**Before**
<img width="1431" alt="image" src="https://user-images.githubusercontent.com/18520314/223741173-eca8bdd9-e856-47cc-910b-cee0199bee10.png">


**After**
<img width="1401" alt="image" src="https://user-images.githubusercontent.com/18520314/223740992-c49850b8-32f5-4115-9b4e-47d0911c316d.png">
